### PR TITLE
Server components

### DIFF
--- a/src/app/(with-searchbar)/client-component.tsx
+++ b/src/app/(with-searchbar)/client-component.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import ServerComponent from "./server-component";
+
+export default function ClientCompoent() {
+  console.log("클라이언트 컴포넌트");
+  return <ServerComponent />;
+}

--- a/src/app/(with-searchbar)/client-component.tsx
+++ b/src/app/(with-searchbar)/client-component.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import ServerComponent from "./server-component";
+import { ReactNode } from "react";
 
-export default function ClientCompoent() {
+export default function ClientCompoent({ children }: { children: ReactNode }) {
   console.log("클라이언트 컴포넌트");
-  return <ServerComponent />;
+  return <>{children}</>;
 }

--- a/src/app/(with-searchbar)/layout.tsx
+++ b/src/app/(with-searchbar)/layout.tsx
@@ -1,9 +1,10 @@
 import { ReactNode } from "react";
+import Searchbar from "./searchbar";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div>
-      <div>임시서치바</div>
+      <Searchbar />
       {children}
     </div>
   );

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import ClientCompoent from "./client-component";
 import styles from "./page.module.css";
 
 export default function Home() {
-  console.log("서버컴포넌트");
-  return <div className={styles.page}>인덱스 페이지</div>;
+  return (
+    <div className={styles.page}>
+      인덱스 페이지
+      <ClientCompoent />
+    </div>
+  );
 }

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -1,13 +1,14 @@
-"use client";
-
 import ClientCompoent from "./client-component";
 import styles from "./page.module.css";
+import ServerComponent from "./server-component";
 
 export default function Home() {
   return (
     <div className={styles.page}>
       인덱스 페이지
-      <ClientCompoent />
+      <ClientCompoent>
+        <ServerComponent />
+      </ClientCompoent>
     </div>
   );
 }

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import styles from "./page.module.css";
 
 export default function Home() {
+  console.log("서버컴포넌트");
   return <div className={styles.page}>인덱스 페이지</div>;
 }

--- a/src/app/(with-searchbar)/searchbar.tsx
+++ b/src/app/(with-searchbar)/searchbar.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useState } from "react";
+
+export default function Searchbar() {
+  const [search, setSearch] = useState("");
+
+  const onChangeSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+  };
+
+  return (
+    <div>
+      <input value={search} onChange={onChangeSearch} />
+      <button>검색</button>
+    </div>
+  );
+}

--- a/src/app/(with-searchbar)/server-component.tsx
+++ b/src/app/(with-searchbar)/server-component.tsx
@@ -1,0 +1,4 @@
+export default function ServerComponent() {
+  console.log("서버컴포넌트");
+  return <div></div>;
+}

--- a/src/app/book/[id]/page.tsx
+++ b/src/app/book/[id]/page.tsx
@@ -1,9 +1,4 @@
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  console.log(params);
-  const { id } = await params;
-  return <div></div>;
+export default async function Page({ params }: { params: { id: string } }) {
+  const { id } = params;
+  return <div>Book ID: {id}</div>;
 }


### PR DESCRIPTION
- 서버컴포넌트 vs. 클라이언트컴포넌트
넥스트에서 컴포넌트를 생성하면 기본형태가 서버컴포넌트
클라이언트 컴포넌트를 사용하고자 한다면
```
"use client";
```
클라이언트 컴포넌트를 사용하는 경우? 브라우저 상호작용이 필요한 경우임

`서버컴포넌트`에서 콘솔을 찍으면
![iShot_2025-01-11_11 25 43](https://github.com/user-attachments/assets/4c01f58d-f77e-4ed5-aced-28401cbd05f9)
클라이언트 콘솔에는 안찍힘

`클라이언트컴포넌트`에서 콘솔을 찍으면
![iShot_2025-01-11_11 26 16](https://github.com/user-attachments/assets/f84b9a33-0d6a-451b-a409-f9dbb54812c4)
서버에서 한 번, 클라이언트에서 한 번 총 2번 호출됨

- 그렇다면, 클라이언트 컴포넌트에서 서버컴포넌트를 import해서 사용하는 경우라면?
![iShot_2025-01-11_11 41 44](https://github.com/user-attachments/assets/1cf6068b-d633-45a4-8ca5-6a8e468bdc8e)
원래 오류가 발생하는게 맞음. 그런데 그냥 자동으로 클라이언트 컴포넌트에서 서버컴포넌트를 호출해서 사용하면 클라이언트 컴포넌트 취급을 해줌
![iShot_2025-01-11_11 42 21](https://github.com/user-attachments/assets/70423162-02d9-4e59-98df-98aede5eed83)

- 최대한 클라이언트 컴포넌트에서 서버컴포넌트를 호출하는 상황은 지양해야함
그렇다면, 해결 방법은? {children}으로 상속해서 사용하자
![iShot_2025-01-11_11 47 03](https://github.com/user-attachments/assets/c68bff95-7fef-4a14-a516-5397991cb45c)
![iShot_2025-01-11_11 47 12](https://github.com/user-attachments/assets/04605b91-2b2c-4cc5-9d67-a1cb9cdd170c)

그렇다면 각각의 역할을 함
![iShot_2025-01-11_11 47 12](https://github.com/user-attachments/assets/086e76ef-5b36-4158-83b2-601e43824d79)

