### PR TITLE
Feat: 데이터 페치 작업

### DIFF
--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -2,7 +2,11 @@ import BookItem from "@/components/book-item";
 import style from "./page.module.css";
 import books from "@/mock/books.json";
 
-export default function Home() {
+export default async function Home() {
+  const response = await fetch(`http://localhost:12345/book`);
+  const result = await response.json();
+  console.log(result);
+
   return (
     <div className={style.container}>
       <section>


### PR DESCRIPTION
- 데이터 페칭(app router)
기존, getServerSideProps, getStaticProps는 app 라우터에서는 사용되지 않음
왜? 이제 `서버컴포넌트`에서도 async await fetch를 사용할 수 있게됨
원래 서버컴포넌트에서는 비동기함수를 사용하지 않았음 

리액트 특징
1) React는 컴포넌트를 호출, JSX를 반환, 이를 DOM에 렌더링
- 비동기 함수가 반환하는 값은 Promise이므로 React는 이를 처리할 방법이 없음
- async는 항상 Promise를 반환하는데, React는 Promise를 기다려주지 않음 그래서 렌더링에서 문제가 발생!
2) 비동기 작업 하는 거 같았는데??
- React의 컴포넌트 함수는 렌더링만 담당
- useEffect 등 훅에처 처리하는 것임